### PR TITLE
Adds menu activating.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,16 @@ fn main() -> anyhow::Result<()> {
     let event_loop = EventLoop::<()>::new();
     let mut ctx = GameContext::new(&event_loop)?;
     let mut states = StateManager::<GameContext>::new(4);
-    let main_menu = Box::new(Menu::new(String::from("Main"), ["Exit"]));
+    let main_menu = Box::new(
+        Menu::new(String::from("Main"), ["Exit"]).set_callback(Box::new(
+            |_ctx, name| -> anyhow::Result<state_manager::Transition<GameContext>> {
+                if name == "Exit" {
+                    return Ok(state_manager::Transition::Pop(1));
+                }
+                Ok(state_manager::Transition::None)
+            },
+        )),
+    );
     states.push_state(main_menu, &mut ctx)?;
     event_loop.run(move |event, _, _| {
         if ctx.feed_event(&event) {


### PR DESCRIPTION
This adds the activating functionality to the Menu struct, main.rs was changed to reflect it, it now looks like this
```
mod context;
mod menu;
mod sound;
mod state_manager;

use winit::event_loop::EventLoop;

use crate::{context::GameContext, menu::Menu, state_manager::StateManager};

fn main() -> anyhow::Result<()> {
    let event_loop = EventLoop::<()>::new();
    let mut ctx = GameContext::new(&event_loop)?;
    let mut states = StateManager::<GameContext>::new(4);
    let main_menu = Box::new(
        Menu::new(String::from("Main"), ["Exit"]).set_callback(Box::new(
            |_ctx, name| -> anyhow::Result<state_manager::Transition<GameContext>> {
                if name == "Exit" {
                    return Ok(state_manager::Transition::Pop(1));
                }
                Ok(state_manager::Transition::None)
            },
        )),
    );
    states.push_state(main_menu, &mut ctx)?;
    event_loop.run(move |event, _, _| {
        if ctx.feed_event(&event) {
            // Todo: Better error handling
            if !states.on_update(&mut ctx).unwrap() {
                std::process::exit(0);
            }
        }
    });
}
```
The basic idea is having the callback control the state with the Transition enum and giving it what menu item was pressed as a cloned String from the items vec from the menu, It's None by default and uses the builder pattern to make it possible for a callback to not be added while not reducing readability. If it was None the activate function returns Transition::None By default.